### PR TITLE
Use the centos7 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM signiant/docker-jenkins-centos-base:centos6
+FROM signiant/docker-jenkins-centos-base:centos7
 MAINTAINER devops@signiant.com
 
 #install RVM 1.9.3


### PR DESCRIPTION
Did a test promotion with a new container built using centos7 and didn't see any issues.