### PR TITLE
Use the centos7-java8 base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM signiant/docker-jenkins-centos-base:centos7
+FROM signiant/docker-jenkins-centos-base:centos7-java8
 MAINTAINER devops@signiant.com
 
 #install RVM 1.9.3


### PR DESCRIPTION
Feel free to take a look at the centos7-java8 branch for the centos base container (https://github.com/Signiant/docker-jenkins-centos-base/tree/centos7-java8) and do a diff with the centos7 branch, but the only changes are:
- download and install java 8 (8u113) instead of 7 (7u79 - which is no longer available), 
- DON'T run the 'alternatives --install' commands for /usr/bin/java, /usr/bin/javaws and /usr/bin/javac because they aren't needed.

Have tested a deploy of a microservice using this image